### PR TITLE
Accommodate paths with blanks (dotdir on Windows sometimes)

### DIFF
--- a/src/PairPlot.inp
+++ b/src/PairPlot.inp
@@ -285,7 +285,7 @@ function scalar send_to_gnuplot (const string buffer,
         print buffer
     end outfile
 
-    catch gnuplot --input=@mytemp --output=@filename
+    catch gnuplot --input="@mytemp" --output="@filename"
 
     return $error
 end function


### PR DESCRIPTION
Hi Artur (writing in English if others from the gretl team want to take a look), I believe the one-line change in this new branch (in the fork) would be enough to fix the problem with blanks in the dotdir path.
Of course the changelog and spec file also would have to be updated before release...
cheers
sven