### PR TITLE
minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ The user can control the following aspects by adding the respective parameter to
 
 - `centroid`: string, Highlight the centroid of the 2-dim. data. Possible options are `mean`, `median` and `none` (default: "none"). If a `factor` series is passed, the centroid for each distinct factor is shown.
 - `centroid_label`: bool, Show the label of the centroid statistics of TRUE, otherwise do not show of FALSE (default: FALSE).
-- `centroid_linewidth`: int, Width of the point (default: 4).
-- `centroid_pointsize`: int, Size of the point (default: 4).
+- `centroid_linewidth`: scalar, Width of the point (default: 2).
+- `centroid_pointsize`: scalar, Size of the point (default: 2).
 - `filename`: string, Path plus filename plus file type. (optional, default: `display` which draws the resulting plot directly at the screen). Currently figures can only be stored in **png** format.
 - `fontsize`: int, Control the font size of the labels default: 12.
 - `grid`: bool, Draw a grid in the background if TRUE (=1) (default: FALSE)
-- `height`: int, Height of the canvas plot (default: 600).
+- `height`: scalar, Height of the canvas plot (default: 600).
 - `key`: bool, If the `factor` series is provided, a legend shows the color and point pattern for each distinct value of the `factor` variable. Default: 1 (TRUE).
 - `key_fontsize` int, Control the font size for the key. Default: 8
 - `key_position`: string, Controls the position of the legend in each subplot (use standard gnuplot options). default: "top left".
@@ -63,9 +63,13 @@ The user can control the following aspects by adding the respective parameter to
 - **(iv)** "column": Works like type "row" but subplots are arranged in a single column instead.
 
 - `use_circles`: bool, Draw circles instead of points if set to 1 (TRUE), default: 0 (FALSE).
-- `width`: int, Width of the canvas plot (default: 900).
+- `width`: scalar, Width of the canvas plot (default: 900).
 
 # Changelog
+
+* **v0.96 (February 2024)**
+	* Set all terminals to 'noenhanced' mode to respect eventual underscores in variable names
+	* Allow the parameters 'centroid_pointsize', 'centroid_linewidth', 'width' and 'height' to be scalar values instead of integers.
 
 * **v0.95 (December 2023)**
 	* Bugfix: Path with blanks failed under Windows sometimes.

--- a/src/PairPlot.inp
+++ b/src/PairPlot.inp
@@ -425,7 +425,7 @@ function void write_centroids (const list yx, const bundle self)
         endif
 
         # Draw some symbol for the i-th centroid
-        printf "set label %d \"%s\" at %g,%g point ps %d pt %d lw %d",
+        printf "set label %d \"%s\" at %g,%g point ps %g pt %d lw %g",
             self.ith_factor, label, centroids[1], centroids[2],
             self.centroid_pointsize, self.pointtype[self.ith_factor],
             self.centroid_linewidth
@@ -552,7 +552,7 @@ function string write_options (const bundle self)
             printf "set grid ls 12\n"
         endif
 
-        printf "set pointsize %.2f\n", self.pointsize
+        printf "set pointsize %g\n", self.pointsize
 
         # No documented yet, as it errors
         /*
@@ -638,10 +638,10 @@ function string filetype_to_terminal_map (const string filetype)
     /* Return gnuplot terminal name depending on filetype. */
 
     map =_(\
-            png = "pngcairo",\
-            pdf = "pdf",\
-            eps = "postscript eps enhanced",\
-            svg ="svg color"\
+            png = "pngcairo noenhanced",\
+            pdf = "pdf noenhanced",\
+            eps = "postscript eps color noenhanced",\
+            svg ="svg noenhanced"\
           )
 
     return map["@filetype"]
@@ -656,7 +656,7 @@ function string construct_terminal_cmd (const bundle self)
     string set_cmd = "set terminal "
     set_cmd += filetype_to_terminal_map(self.filetype)
     set_cmd += sprintf(" font ',%d' ", self.fontsize)
-    set_cmd += sprintf(" size %d, %d\n", self.width, self.height)
+    set_cmd += sprintf(" size %g, %g\n", self.width, self.height)
 
     set force_decpoint off
 

--- a/src/PairPlot.spec
+++ b/src/PairPlot.spec
@@ -1,7 +1,7 @@
 author = Artur Tarassow
 email = atecon@posteo.de
-version = 0.95
-date = 2023-12-14
+version = 0.96
+date = 2024-02-10
 description = Scatterplot matrix with factor separation
 tags = C88
 min-version = 2022d

--- a/src/PairPlot_help.md
+++ b/src/PairPlot_help.md
@@ -38,12 +38,12 @@ The user can control the following aspects by adding the respective parameter to
 
 - `centroid`: string, Highlight the centroid of the 2-dim. data. Possible options are `mean`, `median` and `none` (default: "none"). If a `factor` series is passed, the centroid for each distinct factor is shown.
 - `centroid_label`: bool, Show the label of the centroid statistics of TRUE, otherwise do not show of FALSE (default: FALSE).
-- `centroid_linewidth`: int, Width of the point (default: 4).
-- `centroid_pointsize`: int, Size of the point (default: 4).
+- `centroid_linewidth`: scalar, Width of the point (default: 2).
+- `centroid_pointsize`: scalar, Size of the point (default: 2).
 - `filename`: string, Path plus filename plus file type. (optional, default: `display` which draws the resulting plot directly at the screen). Currently figures can only be stored in **png** format.
 - `fontsize`: int, Control the font size of the labels default: 12.
 - `grid`: bool, Draw a grid in the background if TRUE (=1) (default: FALSE)
-- `height`: int, Height of the canvas plot (default: 600).
+- `height`: scalar, Height of the canvas plot (default: 600).
 - `key`: bool, If the `factor` series is provided, a legend shows the color and point pattern for each distinct value of the `factor` variable. Default: 1 (TRUE).
 - `key_fontsize` int, Control the font size for the key. Default: 8
 - `key_position`: string, Controls the position of the legend in each subplot (use standard gnuplot options). default: "top left".
@@ -63,9 +63,13 @@ The user can control the following aspects by adding the respective parameter to
 - **(iv)** "column": Works like type "row" but subplots are arranged in a single column instead.
 
 - `use_circles`: bool, Draw circles instead of points if set to 1 (TRUE), default: 0 (FALSE).
-- `width`: int, Width of the canvas plot (default: 900).
+- `width`: scalar, Width of the canvas plot (default: 900).
 
 # Changelog
+
+* **v0.96 (February 2024)**
+	* Set all terminals to 'noenhanced' mode to respect eventual underscores in variable names
+	* Allow the parameters 'centroid_pointsize', 'centroid_linewidth', 'width' and 'height' to be scalar values instead of integers.
 
 * **v0.95 (December 2023)**
 	* Bugfix: Path with blanks failed under Windows sometimes.


### PR DESCRIPTION
* Set all terminals to 'noenhanced' mode to respect eventual underscores in variable names
* Allow the parameters 'centroid_pointsize', 'centroid_linewidth', 'width' and 'height' to be scalar values instead of integers.